### PR TITLE
advise: use rawBody as the urllib data

### DIFF
--- a/lib/http_proxy.js
+++ b/lib/http_proxy.js
@@ -114,7 +114,7 @@ class HttpProxy {
         // urllib default use querystring to stringify form data which don't support nested object
         // will use qs instead of querystring to support nested object by set nestedQuerystring to true.
         options.nestedQuerystring = true;
-        options.data = requestBody;
+        options.data = rawBody || requestBody;
         // urllib wll auto set
         delete options.headers['content-length'];
       } else {


### PR DESCRIPTION
use rawBody as the urllib data

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

这里转发请求的时候，是否应该使用rawBody呢？使用requestBody可能会导致请求不一样，以下是case：
在content-type为 x-www-form-urlencoded 的情况下，是可以传递数组的，如：

```
var formdata = new FormData()
FormData.append('arr[]', 1)
FormData.append('arr[]', 2)
```

这种请求，在egg这里解析后，requestBody为
```
{ arr: ["1", "2"]}
```

rawBody为
```
arr%5B%5D=1&arr%5B%5D=2
```

如果将requestBody作为urllib的body传输
则发送的formdata实质为：
```
arr[1]: 1
arr[2]: 2
```
即
arr%5B1%5D=1&arr%5B2%5D=2

因此想问下这里为啥不直接采用rawBody呢