### PR TITLE
fix: use pipeline instead of pipe to prevent memory leaks

### DIFF
--- a/lib/http_proxy.js
+++ b/lib/http_proxy.js
@@ -5,6 +5,9 @@ const FormStream = require('formstream');
 const ContentType = require('content-type');
 const address = require('address');
 const assert = require('assert');
+const { promisify } = require("util");
+const { pipeline } = require("stream");
+const pipelineAsync = promisify(pipeline);
 
 class HttpProxy {
   constructor(ctx) {
@@ -158,7 +161,7 @@ class HttpProxy {
     } else {
       ctx.respond = false;
       ctx.res.flushHeaders();
-      res.pipe(ctx.res);
+      await pipelineAsync(res, ctx.res);
     }
   }
 }


### PR DESCRIPTION
fix: use pipeline instead of pipe to prevent memory leaks

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
Use pipeline instead of .pipe.

##### Description of change
<!-- Provide a description of the change below this comment. -->
When the `res` in `res.pipe` has an error or closes prematurely, `ctx.res` will not be freed, resulting in a memory leak. So we use `pipeline` to ensure that both streams are correctly released by the destroy method call.

you can check `pipeline` on node.org doc for detail:  https://nodejs.org/docs/latest-v16.x/api/stream.html#streampipelinesource-transforms-destination-callback

<img width="1244" alt="截屏2023-08-30 下午3 21 58" src="https://github.com/eggjs/egg-http-proxy/assets/3158736/1fd0304a-08ff-49e6-ba55-627bb381c57f">
