### PR TITLE
feat: add httpsAgent config for keepalive on https request

### DIFF
--- a/lib/http_proxy.js
+++ b/lib/http_proxy.js
@@ -32,6 +32,7 @@ class HttpProxy {
     const defaultOptions = {
       timeout: this.config.timeout,
       agent: this.config.agent,
+      httpsAgent: this.config.agent,
       streaming: true,
       followRedirect: false,
       beforeResponse: undefined,

--- a/lib/http_proxy.js
+++ b/lib/http_proxy.js
@@ -32,7 +32,7 @@ class HttpProxy {
     const defaultOptions = {
       timeout: this.config.timeout,
       agent: this.config.agent,
-      httpsAgent: this.config.agent,
+      httpsAgent: this.config.httpsAgent,
       streaming: true,
       followRedirect: false,
       beforeResponse: undefined,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
add httpsAgent for keepalive requesting

##### Description of change
<!-- Provide a description of the change below this comment. -->
according to the doc of egg, we should use `httpsAgent` to disable the https keepalive, the agent field only set the http keepalive configuration. https://www.eggjs.org/zh-CN/core/httpclient#httpsagent-httpsagent

![image](https://github.com/eggjs/egg-http-proxy/assets/3158736/af7bb9e1-2ddc-484b-814e-5f596cc0dffd)

